### PR TITLE
Assets path

### DIFF
--- a/ai2svelte.js
+++ b/ai2svelte.js
@@ -4611,7 +4611,7 @@ function main() {
 
   // Create an <img> tag for the artboard image
   function generateImageHtml(imgFile, imgId, imgClass, imgStyle, ab, settings) {
-    var imgDir = "{ assetsPath }" + settings.image_source_path,
+    var imgDir = "{ assetsPath.replace(new RegExp('/([^/.]+)$'), '/$1/') }" + settings.image_source_path,
       imgAlt = encodeHtmlEntities(settings.image_alt_text || ""),
       html,
       src;

--- a/ai2svelte.js
+++ b/ai2svelte.js
@@ -4611,7 +4611,7 @@ function main() {
 
   // Create an <img> tag for the artboard image
   function generateImageHtml(imgFile, imgId, imgClass, imgStyle, ab, settings) {
-    var imgDir = "{ basePath }" + settings.image_source_path,
+    var imgDir = "{ assetsPath }" + settings.image_source_path,
       imgAlt = encodeHtmlEntities(settings.image_alt_text || ""),
       html,
       src;
@@ -5184,7 +5184,7 @@ function main() {
     var svelteJS = "<script>\r\t";
 
 
-    svelteJS += "export let basePath = './';\r";
+    svelteJS += "export let assetsPath = './';\r";
 
     svelteJS += "\tlet width = null;\r";
     // add prop for onmount function that defaults to noop


### PR DESCRIPTION
Does two things:
- Renames `basePath` to `assetsPath`. Since folks will be filling it in with SvelteKit's `assets` module, figure this name may make it easier to remember what to fill that prop with...
- Adds a regex replace where we use `assetsPath` that guarantees a trailing slash. In SvelteKit `assets` doesn't include one, and I think it adds a barrier to folks if they always have to remember to add it before passing to this prop. Can check the regex [here](https://regex101.com/r/unnmVV/1).