### PR TITLE
adds default for empty assets path base

### DIFF
--- a/ai2svelte.js
+++ b/ai2svelte.js
@@ -4611,7 +4611,7 @@ function main() {
 
   // Create an <img> tag for the artboard image
   function generateImageHtml(imgFile, imgId, imgClass, imgStyle, ab, settings) {
-    var imgDir = "{ assetsPath.replace(new RegExp('/([^/.]+)$'), '/$1/') }" + settings.image_source_path,
+    var imgDir = "{ assetsPath.replace(new RegExp('/([^/.]+)$'), '/$1/') || '/' }" + settings.image_source_path,
       imgAlt = encodeHtmlEntities(settings.image_alt_text || ""),
       html,
       src;


### PR DESCRIPTION
Discovered that our `assetsPath` in SvelteKit from `$app/paths` is actually an empty string, which evaluates to a relative path like `images/...` after replacement.

That breaks paths in the embed previewer locally because it's hosted at a sub-route, `/embed-previewer/`. 

This adds a default option, so if the regex replace returns an empty string, the path still starts from the root, i.e., `/images/...`, which fixes the previewer.

Has no effect on production builds since they are never empty strings after replacement..