### PR TITLE
adds vscode-css-languageservice

### DIFF
--- a/ai2svelte/cep.config.ts
+++ b/ai2svelte/cep.config.ts
@@ -3,17 +3,15 @@ import { version } from "./package.json";
 
 const config: CEP_Config = {
   version,
-  id: "com.reuters-graphics.ai2svelte", 
-  displayName: "ai2svelte-ui", 
+  id: "com.reuters-graphics.ai2svelte",
+  displayName: "ai2svelte-ui",
   symlink: "local",
   port: 3000,
   servePort: 5000,
   startingDebugPort: 8860,
   extensionManifestVersion: 6.0,
   requiredRuntimeVersion: 9.0,
-  hosts: [
-    { name: "ILST", version: "[0.0,99.9]" }, 
-  ],
+  hosts: [{ name: "ILST", version: "[0.0,99.9]" }],
 
   type: "Panel",
   iconDarkNormal: "./src/assets/light-icon.png",
@@ -28,7 +26,7 @@ const config: CEP_Config = {
     {
       mainPath: "./main/index.html",
       name: "main",
-      panelDisplayName: "ai2svelte", 
+      panelDisplayName: "ai2svelte",
       autoVisible: true,
       width: 300,
       height: 350,

--- a/ai2svelte/package-lock.json
+++ b/ai2svelte/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "com.reuters-graphics.ai2svelte",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.reuters-graphics.ai2svelte",
-      "version": "0.0.5",
+      "version": "0.0.8",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
+        "@codemirror/lang-sass": "^6.0.2",
         "@codemirror/lang-yaml": "^6.1.2",
         "@codemirror/legacy-modes": "^6.5.1",
+        "@eslint/css": "^0.13.0",
         "@floating-ui/dom": "^1.7.2",
         "@fsegurai/codemirror-theme-bundle": "^6.2.0",
         "@reuters-graphics/svelte-markdown": "^0.0.3",
@@ -19,7 +21,9 @@
         "json5": "^2.2.3",
         "postcss": "^8.5.6",
         "postcss-safe-parser": "^7.0.1",
-        "prettier": "^3.6.2"
+        "prettier": "^3.6.2",
+        "vscode-css-languageservice": "^6.3.8",
+        "vscode-languageserver-textdocument": "^1.0.12"
       },
       "devDependencies": {
         "@babel/core": "^7.19.0",
@@ -31,6 +35,7 @@
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.16.0",
         "@babel/runtime": "^7.16.3",
+        "@codemirror/lint": "^6.9.0",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^28.0.3",
         "@rollup/plugin-image": "^3.0.3",
@@ -46,11 +51,13 @@
         "babel-preset-env": "^1.7.0",
         "core-js": "3",
         "cross-env": "^7.0.3",
+        "csslint": "^1.0.5",
         "es-check": "^9.1.4",
         "eslint": "^9.30.1",
         "extendscriptr": "^1.2.5",
         "fs-extra": "^10.0.0",
         "postcss-prettify": "^0.3.4",
+        "postcss-scss": "^4.0.9",
         "rimraf": "^3.0.2",
         "rollup": "^4.42.0",
         "rollup-plugin-multi-input": "^1.5.0",
@@ -2050,6 +2057,19 @@
         "@lezer/css": "^1.1.7"
       }
     },
+    "node_modules/@codemirror/lang-sass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz",
+      "integrity": "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/sass": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/lang-yaml": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.2.tgz",
@@ -2089,9 +2109,9 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.8.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
-      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.0.tgz",
+      "integrity": "sha512-wZxW+9XDytH3SKvS8cQzMyQCaaazH8XL1EMHleHe00wVzsv7NBQKVW2yzEHrRhmM7ZOhVdItPbvlRBvMp9ej7A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -2677,6 +2697,64 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/css": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/css/-/css-0.13.0.tgz",
+      "integrity": "sha512-nPUDpWDKq3uXrvvft+wfZmx7jCF/TLMzXassUrSxLTumQ7Cr4F/HTUcibVit2MdbSqfgAkWgLRc6Gns5/PRAEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.16.0",
+        "@eslint/css-tree": "^3.6.5",
+        "@eslint/plugin-kit": "^0.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/css-tree": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-3.6.6.tgz",
+      "integrity": "sha512-C3YiJMY9OZyZ/3vEMFWJIesdGaRY6DmIYvmtyxMT934CbrOKqRs+Iw7NWSRlJQEaK4dPYy2lZ2y1zkaj8z0p5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.23.0",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@eslint/css-tree/node_modules/mdn-data": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.23.0.tgz",
+      "integrity": "sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/@eslint/css/node_modules/@eslint/core": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/css/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
+      "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.16.0",
+        "levn": "^0.4.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3376,6 +3454,17 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/sass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/sass/-/sass-1.1.0.tgz",
+      "integrity": "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/yaml": {
@@ -4484,7 +4573,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -4816,6 +4904,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "license": "MIT"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -6726,6 +6820,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -7227,6 +7331,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/csslint": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/csslint/-/csslint-1.0.5.tgz",
+      "integrity": "sha512-GXGpPqGIuEBKesM4bt2IKFrzDKpemh9wVZRHVuculUErar554QrXHOonhgkBOP3uiZzbAETz0N2A4oWlIoxPuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "~2.1.0",
+        "parserlib": "~1.1.1"
+      },
+      "bin": {
+        "csslint": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dash-ast": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
@@ -7235,9 +7356,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9473,7 +9594,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -10574,6 +10694,13 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parserlib": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parserlib/-/parserlib-1.1.1.tgz",
+      "integrity": "sha512-e1HbF3+7ASJ/uOZirg5/8ZfPljTh100auNterbHB8TUs5egciuWQ2eX/2al8ko0RdV9Xh/5jDei3jqJAmbTDcg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path": {
       "version": "0.12.7",
       "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
@@ -10855,6 +10982,33 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/postcss-scss": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+      "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.29"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
@@ -10872,7 +11026,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -12698,7 +12851,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -13143,6 +13295,36 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.8.tgz",
+      "integrity": "sha512-dBk/9ullEjIMbfSYAohGpDOisOVU1x2MQHOeU12ohGJQI7+r0PCimBwaa/pWpxl/vH4f7ibrBfxIZY3anGmHKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "license": "MIT"
     },
     "node_modules/w3c-keyname": {

--- a/ai2svelte/package.json
+++ b/ai2svelte/package.json
@@ -16,8 +16,10 @@
   },
   "dependencies": {
     "@codemirror/lang-css": "^6.3.1",
+    "@codemirror/lang-sass": "^6.0.2",
     "@codemirror/lang-yaml": "^6.1.2",
     "@codemirror/legacy-modes": "^6.5.1",
+    "@eslint/css": "^0.13.0",
     "@floating-ui/dom": "^1.7.2",
     "@fsegurai/codemirror-theme-bundle": "^6.2.0",
     "@reuters-graphics/svelte-markdown": "^0.0.3",
@@ -26,7 +28,9 @@
     "json5": "^2.2.3",
     "postcss": "^8.5.6",
     "postcss-safe-parser": "^7.0.1",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "vscode-css-languageservice": "^6.3.8",
+    "vscode-languageserver-textdocument": "^1.0.12"
   },
   "devDependencies": {
     "@babel/core": "^7.19.0",
@@ -38,6 +42,7 @@
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.16.0",
     "@babel/runtime": "^7.16.3",
+    "@codemirror/lint": "^6.9.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-image": "^3.0.3",
@@ -53,11 +58,13 @@
     "babel-preset-env": "^1.7.0",
     "core-js": "3",
     "cross-env": "^7.0.3",
+    "csslint": "^1.0.5",
     "es-check": "^9.1.4",
     "eslint": "^9.30.1",
     "extendscriptr": "^1.2.5",
     "fs-extra": "^10.0.0",
     "postcss-prettify": "^0.3.4",
+    "postcss-scss": "^4.0.9",
     "rimraf": "^3.0.2",
     "rollup": "^4.42.0",
     "rollup-plugin-multi-input": "^1.5.0",

--- a/ai2svelte/src/js/main/Tabs/Styles.svelte
+++ b/ai2svelte/src/js/main/Tabs/Styles.svelte
@@ -71,14 +71,6 @@
   let cssString: string = $derived.by(() => {
     // don't update while its fetching settings from AI
     if (!$updateInProgress) {
-      //   let string = styleObjectToString($styles);
-
-      //   const string = postcss().process($styles, {
-      //     parser: parse,
-      //     syntax: scss,
-      //   }).css;
-
-      //   console.log("styles:", generateAllMixins($styles));
       const string = $styles?.root?.toString() || "";
 
       //   if (window.cep) {
@@ -104,7 +96,6 @@
   // clear card selection
   $effect(() => {
     if (cssSelector) {
-      console.log("selector", cssSelector);
       clearShadowSelection();
       previousSelector = cssSelector;
     }
@@ -130,7 +121,6 @@
     const adapter = AIEventAdapter.getInstance();
     adapter.addEventListener(AIEvent.ART_SELECTION_CHANGED, async (e: any) => {
       if ($ai2svelteInProgress) return;
-      console.log("Selection changed:");
       await detectIdentifier();
     });
   }
@@ -143,8 +133,6 @@
           return result;
         });
     }
-
-    console.log($styles);
 
     allShadows = [...JSON5.parse(shadows)]
       .map((x) => ({
@@ -259,8 +247,6 @@
           object = await result;
         });
 
-      console.log("styles", $styles.root?.nodes);
-
       styles.set(object);
     } catch (error) {
       // ignore errors cause user might still be typing the style
@@ -318,17 +304,6 @@
         rule = postcss.rule({ selector: cssSelector });
         $styles.root.append(rule);
       }
-      //   if (!$styles[cssSelector]) {
-      //     $styles[cssSelector] = {};
-      //   }
-
-      //   const animationStyle = Object.keys($styles[cssSelector]).find(
-      //     (x: string) => x.includes("animation:")
-      //   );
-
-      //   const animationKey = Object.keys($styles[cssSelector]).includes(
-      //     "animation"
-      //   );
 
       // Create a comment node
       const comment = postcss.comment({
@@ -346,11 +321,6 @@
       // Add or update a declaration
       rule.append(animationInclude);
 
-      //   $styles[cssSelector].push(
-      //     `/* ${animationIdentifier} ${animationDefinition} */`
-      //   );
-      //   $styles[cssSelector].push(animationUsage);
-
       let animationDeclExists = false;
       let existingValue = "";
       rule.walkDecls((decl) => {
@@ -365,22 +335,6 @@
         // Add animation declaration
         rule.append({ prop: "animation", value: animationRule });
       }
-
-      // if 'animation' rule isn't included, add it
-      //   if (!animationKey) {
-      //     // $styles[cssSelector].push(`animation: ${animationRule}`);
-      //     // $styles[cssSelector] = {
-      //     //   ...$styles[cssSelector],
-      //     //   animation: animationRule,
-      //     // };
-      //   } else {
-      //     // const regex = new RegExp(/.*animation:\s(.*)/);
-      //     // const existingAnimations = $styles[cssSelector]["animation"];
-      //     // if (existingAnimations) {
-      //     //   $styles[cssSelector]["animation"] =
-      //     //     `${existingAnimations}, ${animationRule}`;
-      //     // }
-      //   }
     } else {
       rule.walkDecls((decl) => {
         if (decl.prop === "animation") {
@@ -411,66 +365,7 @@
       });
 
       checkIfRuleIsEmpty(rule);
-
-      // console.log("id:" + animationIdentifier);
-      //   const regexCheck = new RegExp(`\\b${animationIdentifier}\\b`);
-
-      //   const animationStyle = Object.keys($styles[cssSelector]).find(
-      //     (x: string) => x.includes("animation:")
-      //   );
-
-      //   if (animationStyle) {
-      //     const regex = new RegExp(/.*animation:(.*)/);
-      //     const existingAnimations = animationStyle.match(regex);
-      //     const animString = existingAnimations
-      //       ? existingAnimations[1]
-      //       : undefined;
-
-      //     if (animString) {
-      //       const animRegex = new RegExp(`\\s*${animationName}([^,)]*)`);
-      //       const newAnimString = animString
-      //         .replace(animRegex, "")
-      //         .split(",")
-      //         .filter((x) => x !== "")
-      //         .join(",");
-
-      //       const index = Object.keys($styles[cssSelector]).findIndex(
-      //         (x) => x == animationStyle
-      //       );
-
-      //       if (index > -1) {
-      //         if (newAnimString == "") {
-      //           //   $styles[cssSelector].splice(index, 1);
-      //           delete $styles[cssSelector][animationStyle];
-      //         } else {
-      //           //   $styles[cssSelector][index] = `animation: ${newAnimString}`;
-      //           $styles[cssSelector] = {
-      //             ...$styles[cssSelector],
-      //             [`animation: ${newAnimString}`]: true,
-      //           };
-      //         }
-      //       }
-      //   }
     }
-
-    //   const indexes = $styles[cssSelector]
-    //     .map((x, i) => (regexCheck.test(x) ? i : null))
-    //     .filter((x) => x !== null && x >= 0);
-
-    //   const indexSet = new Set(indexes);
-
-    //   const arrayWithValuesRemoved = $styles[cssSelector].filter(
-    //     (value, i) => !indexSet.has(i)
-    //   );
-
-    //   $styles[cssSelector] = [...arrayWithValuesRemoved];
-    // }
-
-    // if ($styles[cssSelector].length == 0) {
-    //   delete $styles[cssSelector];
-    // } else {
-    //   // add all animations
-    // }
 
     $styles = $styles;
   }

--- a/ai2svelte/yarn.lock
+++ b/ai2svelte/yarn.lock
@@ -1029,7 +1029,7 @@
     "@codemirror/view" "^6.27.0"
     "@lezer/common" "^1.1.0"
 
-"@codemirror/lang-css@^6.3.1":
+"@codemirror/lang-css@^6.2.0", "@codemirror/lang-css@^6.3.1":
   version "6.3.1"
   resolved "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz"
   integrity sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==
@@ -1039,6 +1039,17 @@
     "@codemirror/state" "^6.0.0"
     "@lezer/common" "^1.0.2"
     "@lezer/css" "^1.1.7"
+
+"@codemirror/lang-sass@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz"
+  integrity sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==
+  dependencies:
+    "@codemirror/lang-css" "^6.2.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.0.2"
+    "@lezer/sass" "^1.0.0"
 
 "@codemirror/lang-yaml@^6.1.2":
   version "6.1.2"
@@ -1072,10 +1083,10 @@
   dependencies:
     "@codemirror/language" "^6.0.0"
 
-"@codemirror/lint@^6.0.0":
-  version "6.8.5"
-  resolved "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz"
-  integrity sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==
+"@codemirror/lint@^6.0.0", "@codemirror/lint@^6.9.0":
+  version "6.9.0"
+  resolved "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.0.tgz"
+  integrity sha512-wZxW+9XDytH3SKvS8cQzMyQCaaazH8XL1EMHleHe00wVzsv7NBQKVW2yzEHrRhmM7ZOhVdItPbvlRBvMp9ej7A==
   dependencies:
     "@codemirror/state" "^6.0.0"
     "@codemirror/view" "^6.35.0"
@@ -1293,6 +1304,30 @@
   dependencies:
     "@types/json-schema" "^7.0.15"
 
+"@eslint/core@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz"
+  integrity sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==
+  dependencies:
+    "@types/json-schema" "^7.0.15"
+
+"@eslint/css-tree@^3.6.5":
+  version "3.6.6"
+  resolved "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-3.6.6.tgz"
+  integrity sha512-C3YiJMY9OZyZ/3vEMFWJIesdGaRY6DmIYvmtyxMT934CbrOKqRs+Iw7NWSRlJQEaK4dPYy2lZ2y1zkaj8z0p5A==
+  dependencies:
+    mdn-data "2.23.0"
+    source-map-js "^1.0.1"
+
+"@eslint/css@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.npmjs.org/@eslint/css/-/css-0.13.0.tgz"
+  integrity sha512-nPUDpWDKq3uXrvvft+wfZmx7jCF/TLMzXassUrSxLTumQ7Cr4F/HTUcibVit2MdbSqfgAkWgLRc6Gns5/PRAEA==
+  dependencies:
+    "@eslint/core" "^0.16.0"
+    "@eslint/css-tree" "^3.6.5"
+    "@eslint/plugin-kit" "^0.4.0"
+
 "@eslint/eslintrc@^3.3.1":
   version "3.3.1"
   resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz"
@@ -1324,6 +1359,14 @@
   integrity sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==
   dependencies:
     "@eslint/core" "^0.15.1"
+    levn "^0.4.1"
+
+"@eslint/plugin-kit@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz"
+  integrity sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==
+  dependencies:
+    "@eslint/core" "^0.16.0"
     levn "^0.4.1"
 
 "@floating-ui/core@^1.7.2":
@@ -1609,6 +1652,15 @@
   integrity sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==
   dependencies:
     "@lezer/common" "^1.0.0"
+
+"@lezer/sass@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@lezer/sass/-/sass-1.1.0.tgz"
+  integrity sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
 
 "@lezer/yaml@^1.0.0":
   version "1.0.3"
@@ -2161,6 +2213,11 @@
   dependencies:
     "@typescript-eslint/types" "8.38.0"
     eslint-visitor-keys "^4.2.1"
+
+"@vscode/l10n@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz"
+  integrity sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -3324,6 +3381,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clone@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
+
 clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz"
@@ -3657,6 +3719,14 @@ cssesc@^3.0.0:
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
+csslint@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/csslint/-/csslint-1.0.5.tgz"
+  integrity sha512-GXGpPqGIuEBKesM4bt2IKFrzDKpemh9wVZRHVuculUErar554QrXHOonhgkBOP3uiZzbAETz0N2A4oWlIoxPuw==
+  dependencies:
+    clone "~2.1.0"
+    parserlib "~1.1.1"
+
 dash-ast@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz"
@@ -3670,9 +3740,9 @@ debug@^2.6.8:
     ms "2.0.0"
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.7, debug@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz"
-  integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
@@ -5115,6 +5185,11 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+mdn-data@2.23.0:
+  version "2.23.0"
+  resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.23.0.tgz"
+  integrity sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==
+
 media-typer@~0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
@@ -5458,6 +5533,11 @@ parse5@^7.2.1:
   dependencies:
     entities "^6.0.0"
 
+parserlib@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/parserlib/-/parserlib-1.1.1.tgz"
+  integrity sha512-e1HbF3+7ASJ/uOZirg5/8ZfPljTh100auNterbHB8TUs5egciuWQ2eX/2al8ko0RdV9Xh/5jDei3jqJAmbTDcg==
+
 path-browserify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz"
@@ -5566,6 +5646,11 @@ postcss-safe-parser@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz"
   integrity sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==
+
+postcss-scss@^4.0.9:
+  version "4.0.9"
+  resolved "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz"
+  integrity sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==
 
 postcss-selector-parser@^6.1.2:
   version "6.1.2"
@@ -6229,7 +6314,7 @@ smartypants@^0.2.2:
   resolved "https://registry.npmjs.org/smartypants/-/smartypants-0.2.2.tgz"
   integrity sha512-TzobUYoEft/xBtb2voRPryAUIvYguG0V7Tt3de79I1WfXgCwelqVsGuZSnu3GFGRZhXR90AeEYIM+icuB/S06Q==
 
-source-map-js@^1.2.1, "source-map-js@>=0.6.2 <2.0.0":
+source-map-js@^1.0.1, source-map-js@^1.2.1, "source-map-js@>=0.6.2 <2.0.0":
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -6848,6 +6933,31 @@ vm-browserify@^1.0.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vscode-css-languageservice@^6.3.8:
+  version "6.3.8"
+  resolved "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.8.tgz"
+  integrity sha512-dBk/9ullEjIMbfSYAohGpDOisOVU1x2MQHOeU12ohGJQI7+r0PCimBwaa/pWpxl/vH4f7ibrBfxIZY3anGmHKQ==
+  dependencies:
+    "@vscode/l10n" "^0.0.18"
+    vscode-languageserver-textdocument "^1.0.12"
+    vscode-languageserver-types "3.17.5"
+    vscode-uri "^3.1.0"
+
+vscode-languageserver-textdocument@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz"
+  integrity sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==
+
+vscode-languageserver-types@3.17.5:
+  version "3.17.5"
+  resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz"
+  integrity sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==
+
+vscode-uri@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz"
+  integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==
 
 w3c-keyname@^2.2.4:
   version "2.2.8"


### PR DESCRIPTION
Embeds vscode-css-languageservice for SCSS validation in CodeMirror editor for styles. Will look into potential of adding stylelint to the editor if it's easier running in CEP.